### PR TITLE
Docs/adr tooling

### DIFF
--- a/docs/adr/0002-adopt-pre-commit.md
+++ b/docs/adr/0002-adopt-pre-commit.md
@@ -1,0 +1,22 @@
+# ADR 0002: Adopt pre-commit for local and CI checks
+
+- Status: Accepted
+- Date: 2025-08-19
+
+## Context
+We want fast, repeatable code-quality checks that run before changes enter the repository. Relying on contributors to remember linting, formatting, and security scans is error-prone and leads to regressions.
+
+## Decision
+Use **pre-commit** to manage and run hooks locally and in CI.
+- Install via `uv tool install pre-commit` and include `.pre-commit-config.yaml` in the repo.
+- Enable hooks:
+  - `ruff` (lint + `ruff format`), `pyproject-fmt` for config normalization.
+  - Base hygiene: `trailing-whitespace`, `end-of-file-fixer`, `check-merge-conflict`, `check-yaml`, `check-toml`.
+  - Optional: `detect-private-key`, `check-added-large-files`.
+- Run `pre-commit install` and `pre-commit install --hook-type commit-msg` (for Commitizen check, see ADR 0007).
+- In CI, run `pre-commit run --all-files` to enforce parity with local results.
+
+## Consequences
+- Fewer style & formatting diffs; faster feedback near the developer.
+- Slight friction at commit time (hooks run), but overall saves time by catching issues early.
+- CI remains consistent with local checks.

--- a/docs/adr/0003-adopt-makefile-task-runner.md
+++ b/docs/adr/0003-adopt-makefile-task-runner.md
@@ -1,0 +1,28 @@
+# ADR 0003: Standardize developer tasks via Makefile
+
+- Status: Accepted
+- Date: 2025-08-19
+
+## Context
+Common tasks (install, lint, format, test, type-check, run, build) are scattered across tools. A simple, cross-platform entrypoint reduces onboarding time and mistakes.
+
+## Decision
+Provide a **Makefile** as a thin task runner:
+- `.DEFAULT_GOAL := help`; self-documented `help` target using annotated comments.
+- Key targets (invoke via `make <target>`):
+  - `setup` — create/refresh the uv environment and pre-commit hooks.
+  - `lint` — `ruff check .` and configuration validation.
+  - `format` — `ruff format .` and `pyproject-fmt --unsafe`.
+  - `typecheck` — `mypy .` (with Pydantic plugin).
+  - `test` — `pytest -q --maxfail=1` (see ADR 0006).
+  - `cov` — `pytest --cov=src --cov-report=term-missing`.
+  - `run` — `uv run uvicorn app.main:app --reload` (dev) or `ENV=prod` (see ADR 0009).
+  - `build` — `uv build` (Hatchling backend; see ADR 0001).
+  - `docker-build` / `docker-run` — convenience wrappers (see ADR 0008).
+  - `clean` — remove build caches and `.pytest_cache`.
+- Prefer running tools through `uv run` to ensure the pinned environment.
+
+## Consequences
+- Single, memorable interface for contributors.
+- Make is ubiquitous; Windows users may need `make` from Git Bash or similar.
+- Centralized targets reduce duplicated CI config.

--- a/docs/adr/0004-adopt-ruff-and-pyproject-fmt.md
+++ b/docs/adr/0004-adopt-ruff-and-pyproject-fmt.md
@@ -1,0 +1,21 @@
+# ADR 0004: Use Ruff for linting/formatting and pyproject-fmt for config hygiene
+
+- Status: Accepted
+- Date: 2025-08-19
+
+## Context
+We need a fast, consistent style/lint toolchain that works well in hooks and CI without heavy dependencies.
+
+## Decision
+- Adopt **Ruff** for both linting (`ruff check`) and code formatting (`ruff format`).
+- Configure in `pyproject.toml`:
+  - `target-version = "py312"`; enable rulesets: `E`, `F`, `I`, `UP`, `B`, and `RUF` selectively.
+  - Exclude build artifacts and virtualenvs; set `line-length = 100`.
+  - Use `extend-ignore` only when justified and documented.
+- Adopt **pyproject-fmt** to normalize `pyproject.toml` (key ordering, compact arrays, PEP 621 fields).
+- Wire both into pre-commit (see ADR 0002).
+
+## Consequences
+- Extremely fast feedback loop; fewer tool conflicts (no separate Black + isort needed).
+- Some auto-fixes may differ from prior style; minor one-time churn when enabling.
+- pyproject becomes canonical and consistently formatted, easing reviews.

--- a/docs/adr/0005-adopt-mypy-pydantic-and-types-requests.md
+++ b/docs/adr/0005-adopt-mypy-pydantic-and-types-requests.md
@@ -1,0 +1,22 @@
+# ADR 0005: Adopt mypy (strict-ish), Pydantic models, and types-requests
+
+- Status: Accepted
+- Date: 2025-08-19
+
+## Context
+Static typing reduces runtime bugs and clarifies interfaces. The codebase uses FastAPI and external HTTP calls; we want strong typing for request/response models and I/O layers.
+
+## Decision
+- Use **mypy** with a strict-leaning config in `pyproject.toml`:
+  - `python_version = 3.12`, `strict = True` (or equivalently enable: `warn-unused-ignores`, `disallow-any-generics`, `no_implicit_optional`, `warn-redundant-casts`, `warn-return-any`, `warn-unused-configs`).
+  - Allow gradual typing via `[[tool.mypy.overrides]]` for legacy modules; require TODOs with sunset dates.
+  - Enable Pydantic plugin: `plugins = ["pydantic.mypy"]`.
+- Model all external IO with **Pydantic v2** `BaseModel` classes for validation/serialization.
+- Add **types-requests** to supply stubs for the `requests` library used in integrations.
+- Encourage `from __future__ import annotations` and `typing_extensions` as needed.
+- Enforce in CI: `mypy .` and coverage gates on typed code paths.
+
+## Consequences
+- Clear contracts at boundaries; earlier detection of type regressions.
+- Some upfront effort annotating functions and fixtures.
+- Pydantic validation adds small runtime overhead but improves robustness and error messages.

--- a/docs/adr/0006-adopt-pytest.md
+++ b/docs/adr/0006-adopt-pytest.md
@@ -1,0 +1,23 @@
+# ADR 0006: Standardize on pytest for testing
+
+- Status: Accepted
+- Date: 2025-08-19
+
+## Context
+We need reliable, readable tests for both sync and async code (FastAPI endpoints, service layers).
+
+## Decision
+- Use **pytest** with:
+  - `pytest-asyncio` for async tests.
+  - `pytest-cov` for coverage reporting; minimum threshold (e.g., 85%) enforced in CI.
+  - Optional: `pytest-xdist` for parallelization on CI.
+- Conventions:
+  - Tests live in `tests/` mirroring `src/` structure; file pattern `test_*.py`.
+  - Use `@pytest.mark.asyncio` for async tests.
+  - FastAPI: use `httpx.AsyncClient` with the ASGI app for integration tests.
+  - Keep fixtures small, composable; prefer `autouse` only for cross-cutting concerns.
+- CI: `pytest --maxfail=1 --disable-warnings -q` and a separate coverage job for reporting.
+
+## Consequences
+- Consistent testing story across layers.
+- Slight CI time increase with coverage; mitigated via xdist and targeted integration tests.

--- a/docs/adr/0007-adopt-commitizen.md
+++ b/docs/adr/0007-adopt-commitizen.md
@@ -1,0 +1,21 @@
+# ADR 0007: Adopt Commitizen for Conventional Commits and automated versioning
+
+- Status: Accepted
+- Date: 2025-08-19
+
+## Context
+Consistent commit messages improve history readability and enable automated semantic versioning and changelog generation. We already store the package version in a single source of truth.
+
+## Decision
+- Use **Commitizen** (`cz`) with the **conventional commits** preset.
+- Configure in `pyproject.toml`:
+  - `version` source: bump `src/docchat/__about__.py` to stay aligned with our build system (see ADR 0001).
+  - `changelog` generation enabled; tag format `v<version>`.
+- Hook integration:
+  - Add `commit-msg` hook via pre-commit: `cz check --commit-msg-file`.
+  - Prefer `cz commit` locally to guide messages; `cz bump` in release workflow.
+- Enforce in CI: `cz check --rev-range origin/main..HEAD` for PRs.
+
+## Consequences
+- Clean history and automated releases.
+- Requires contributors to follow the guided flow; slight learning curve for first-time users.

--- a/docs/adr/0008-adopt-docker-containerization.md
+++ b/docs/adr/0008-adopt-docker-containerization.md
@@ -1,0 +1,20 @@
+# ADR 0008: Containerize the app with Docker (multi-stage)
+
+- Status: Accepted
+- Date: 2025-08-19
+
+## Context
+We want reproducible builds and a minimal production runtime image. Prior builds required copying license files and manual steps that risk drift across environments.
+
+## Decision
+- Use a **multi-stage Dockerfile**:
+  - **builder stage**: Python slim base, install **uv**, copy `pyproject.toml` and lockfile, perform `uv sync --frozen`, run tests and type checks optionally.
+  - **runtime stage**: Python slim/distroless base; copy only app, dependencies, and required metadata (including `LICENSE` to satisfy dependencies). Run as non-root user.
+- Entrypoint: `uvicorn app.main:app --host 0.0.0.0 --port 8000` (production flags in ADR 0009).
+- Add a `HEALTHCHECK` hitting `/health` endpoint.
+- Provide `docker-compose.yml` (optional) for local dev with env files and volume mounts.
+
+## Consequences
+- Reproducible, cache-friendly builds; smaller attack surface.
+- Slight complexity in Dockerfile; local dev still prefers `uv run` for speed.
+- Need to keep health endpoint stable for orchestrators.

--- a/docs/adr/0009-adopt-fastapi-uvicorn-and-structlog.md
+++ b/docs/adr/0009-adopt-fastapi-uvicorn-and-structlog.md
@@ -1,0 +1,24 @@
+# ADR 0009: FastAPI + Uvicorn + structlog for API and logging
+
+- Status: Accepted
+- Date: 2025-08-19
+
+## Context
+We need a fast Python web framework with first-class typing and pydantic model integration, an efficient ASGI server, and structured logs that play well in containers and observability stacks.
+
+## Decision
+- Framework: **FastAPI** (async-first, pydantic v2 models, OpenAPI auto-docs).
+- Server: **Uvicorn** as the ASGI server.
+  - Dev: `uvicorn app.main:app --reload`.
+  - Prod: `uvicorn app.main:app --workers $UVICORN_WORKERS --host 0.0.0.0 --port 8000`.
+  - Surface readiness via `/health` and optional `/ready` endpoints.
+- Logging: **structlog** configured for JSON output.
+  - Configure processors for timestamp, log level, event, exception info, and request context (method, path, status, latency, request_id).
+  - Bridge `uvicorn`, `uvicorn.access`, and `fastapi` loggers to structlog to avoid duplicate formatting.
+  - Include correlation-id middleware (e.g., read `X-Request-ID` or generate one).
+- Error handling: map validation errors to structured responses; include error codes and `detail` fields.
+
+## Consequences
+- High performance API with self-documentation and strong typing.
+- Simple, container-friendly logging suitable for ELK/Datadog/Grafana.
+- Requires initial logging/middleware wiring; minor overhead for JSON encoding at high QPS.


### PR DESCRIPTION
## Summary

This pull request adds a set of Architecture Decision Records (ADRs) documenting key decisions about the project's architecture and tooling.

## Motivation / Why

- Ensure all major architectural and tooling decisions are **documented for future reference**
- Provide context for choices such as **FastAPI framework selection, Docker setup, structured logging, pre-commit hooks, testing framework, type checking, and commit conventions**.
- Improve **maintainability, on-boarding, and transparency**  for contributors.
- Link commits to issues for automatic tracking (Closes #2 )
- Added ADRs for:
  - Pre-commit
  - Makefile
  - Ruff / pyproject-fmt
  - Mypy / pydantic / types-requests
  - Pytest
  - Commitizen
  - Docker
  - FastAPI / uvicorn / structlog

## Checklist
- [ ] Tests added/updated
- [X] Lint & type-check pass locally
- [X] Docs updated (README/CHANGELOG/CONTRIBUTING)
- [X] Backwards-compatible (or noted as breaking)

## Linked issues
Closes #2 
